### PR TITLE
use ssh instead of https

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pull_schedule: '*/15 * * * *'           # Schedule crontab
 pull_sources: []                        # Define your sources to control
                                         # Ex: pull_sources:
                                         #     - name: myproject
-                                        #       repo: https://github.com/Stouts/Django-application.git
+                                        #       repo: git@github.com:Stouts/Django-application.git
                                         #       version: develop
                                         #       playbook: deploy/playbook.yml
                                         #       vars:
@@ -81,7 +81,7 @@ Example:
     # Followed repositories
     pull_sources:
     - name: myproject
-      repo: https://github.com/Stouts/Django-application.git
+      repo: git@github.com:Stouts/Django-application.git
       version: develop
       playbook: deploy/playbook.yml
       vars:


### PR DESCRIPTION
In both this role README and the ansible-pull docs, it references the https version of a git repo. However, when I try to use that, I get this error:

`fatal: could not read Username for 'https://github.com': No such device or address"`

It wants the github Username/Password instead of using the ssh key.

This PR just reflects that in the README.
